### PR TITLE
Whittle and friends now update logprob storage

### DIFF
--- a/src/whittle/debiasedwhittle.jl
+++ b/src/whittle/debiasedwhittle.jl
@@ -106,7 +106,8 @@ function debiasedwhittle_FG!(F, G, store, model::TimeSeriesModel ,data::GenWhitt
         grad_generalwhittle!(G, store, data)
     end
     if F !== nothing
-        return generalwhittle(store, data)
+        F = generalwhittle(store, data)
+        return F
     end
     return nothing
 end
@@ -131,7 +132,8 @@ function debiasedwhittle_FGH!(F, G, H, store, model::TimeSeriesModel, data::GenW
         grad_generalwhittle!(G, store, data)
     end
     if F !== nothing
-        return generalwhittle(store, data)
+        F = generalwhittle(store, data)
+        return F
     end
     return nothing
 end
@@ -201,7 +203,8 @@ function debiasedwhittle_Fisher!(F, G, H, store, model::TimeSeriesModel, data::G
         grad_generalwhittle!(G, store, data)
     end
     if F !== nothing
-        return generalwhittle(store, data)
+        F = generalwhittle(store, data)
+        return F
     end
     return nothing
 end

--- a/src/whittle/standardwhittle.jl
+++ b/src/whittle/standardwhittle.jl
@@ -111,7 +111,8 @@ function whittle_FG!(F, G, store, model::TimeSeriesModel, data::GenWhittleData)
         grad_generalwhittle!(G, store, data)
     end
     if F !== nothing
-        return generalwhittle(store, data)
+        F = generalwhittle(store, data)
+        return F
     end
     return nothing
 end
@@ -136,7 +137,8 @@ function whittle_FGH!(F, G, H, store, model::TimeSeriesModel, data::GenWhittleDa
         grad_generalwhittle!(G, store, data)
     end
     if F !== nothing
-        return generalwhittle(store, data)
+        F = generalwhittle(store, data)
+        return F
     end
     return nothing
 end


### PR DESCRIPTION
To correct the following issue:

```
# simulate data
n = 2^8
Δ = 1.0
nreps = 1
σ = 0.8
θ = 0.6

#ts = simulate_gp(CorrelatedOU(σ,θ,ρ),n,Δ,nreps)
ts = simulate_gp(OU(σ,θ),n,Δ,nreps)

whittle = WhittleLikelihood(OU, ts[1])
x = [0.5, 0.5]

# store
ℓp0 = 0.0   
∇ℓp1 = zeros(2)
Hℓp1 = zeros(2,2)
# whittle comp
ℓp1 = whittle(ℓp0, ∇ℓp1, Hℓp1,  x)
ℓp0 == ℓp1 # false...
ℓp0 == 0.0 # true, ℓp0 not updated
```

My suggestion for a quick fix.